### PR TITLE
2018_KAKAO_4_프렌즈4블록

### DIFF
--- a/2018_KAKAO_4.cpp
+++ b/2018_KAKAO_4.cpp
@@ -1,0 +1,49 @@
+#include <string>
+#include <vector>
+#include <queue>
+using namespace std;
+
+int solution(int m, int n, vector<string> board) {vector<vector<bool>> visited(m, vector<bool>(n, false));
+    int answer = 0;
+    bool loof = false;
+    while (1) {
+        loof = false;
+        for (int i = 0; i < board.size() - 1; i++) {
+            for (int j = 0; j < board[i].size() - 1; j++) {
+                char c = board[i][j];
+                if (c != '0') {
+                    if (board[i + 1][j] == c && board[i + 1][j + 1] == c && board[i][j + 1] == c) {
+                        for (int k = 0; k < 2; k++)
+                            for (int kk = 0; kk < 2; kk++) {
+                                visited[i + k][j + kk] = true;
+                                loof = true;
+                            }
+                    }
+                }
+            }
+        }
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+                if (visited[i][j]) {
+                    board[i][j] = '0';
+                    visited[i][j] = false;
+                    answer++;
+                }
+        for (int j = 0; j < n; j++) {
+            priority_queue <pair<int,char>> q;
+            for (int i = m - 1; i >= 0; i--) {
+                char c = board[i][j];
+                if (c == '0') q.emplace(10000, '0');
+                else q.emplace(m - i, c);
+            }
+            int i = 0;
+            while (!q.empty()) {
+                board[i][j] = q.top().second;
+                q.pop();
+                i++;
+            }
+        }
+        if (!loof) break;
+    }
+    return answer;
+}


### PR DESCRIPTION
체감상 백준 골드 하위권 그래프 문제 같았다.
왜 처음 우선순위 큐를 활용할 생각을 못했을까....
아무 것도 채워지지 않은 칸에 가중치를 높게 줘서 우선순위 큐에 넣으면 자동으로 그 칸은 가장 뒤로 가버린다. 그리고 캐릭터가 있던 칸은 순번대로 가중치를 주면 알아서 정렬됨..! 이건 다른 문제에도 충분히 활용될 수 있을 것 같다. 비슷한 유형을 본 것 같거든..
그리고 visited배열은 필요없을 것이라 생각했지만, 전체 while반복문이 돌아갈 때마다, 같은 캐릭터 2*2를 묶어줘야 했는데... 제때마다 표시해서 바꿔버리면 다음 탐색에서 오류가 발생한다. 따라서 1차적으로 visited배열로 표시해주고, 그래프 끝까지 탐색 후 visited 배열에 표시된 부분을 board의 '0'으로 바꿔주면서 answer의 개수를 1씩 증가시켜서 해결했다. #그래프#우선순위큐